### PR TITLE
pvcalls: remove unneeded offset during write_ring command

### DIFF
--- a/plat/xen/drivers/pvcalls/pvcalls-front.c
+++ b/plat/xen/drivers/pvcalls/pvcalls-front.c
@@ -692,7 +692,7 @@ int pvcalls_front_sendmsg(struct posix_socket_file *sock,
 		len = INT_MAX;
 
 	for (i = 0; i < msg->msg_iovlen; i++) {
-		sent = __write_ring(map->active.ring, &map->active.data + sent, msg->msg_iov[i].iov_base,
+		sent = __write_ring(map->active.ring, &map->active.data, msg->msg_iov[i].iov_base,
 							msg->msg_iov[i].iov_len);
 		if (sent > 0) {
 			len -= sent;


### PR DESCRIPTION
There is no need to make an offset during write ring command

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>
